### PR TITLE
Allow custom audit rules to be defined via pillar

### DIFF
--- a/audit/files/audit.rules
+++ b/audit/files/audit.rules
@@ -28,4 +28,4 @@
 # Feel free to add below this line. See auditctl man page
 {%- for rule in auditctl.rules %}
 {{ rule }}
-{%-endfor %}
+{%- endfor %}

--- a/audit/files/audit.rules
+++ b/audit/files/audit.rules
@@ -26,4 +26,6 @@
 {%- endif %}
 
 # Feel free to add below this line. See auditctl man page
-
+{%- for rule in auditctl.rules %}
+{{ rule }}
+{%-endfor %}

--- a/audit/files/immutable.rules
+++ b/audit/files/immutable.rules
@@ -1,0 +1,2 @@
+# Make the configuration immutable
+-e 2

--- a/audit/init.sls
+++ b/audit/init.sls
@@ -39,6 +39,21 @@ audispd-conf:
     - mode: 0640
 
 auditd-service:
+  cmd.run:
+    - name: augenrules
+    - require:
+        - pkg: auditd-pkg
+        - file: auditd-sysconfig
+        - file: auditd-conf
+        - file: auditd-rules
+        - file: auditd-immutable
+        - file: audispd-conf
+    - watch:
+        - file: auditd-sysconfig
+        - file: auditd-conf
+        - file: auditd-rules
+        - file: auditd-immutable
+        - file: audispd-conf
   service.running:
     - name: auditd
     - require:

--- a/audit/init.sls
+++ b/audit/init.sls
@@ -20,9 +20,15 @@ auditd-conf:
 
 auditd-rules:
   file.managed:
-    - name: /etc/audit/audit.rules
+    - name: /etc/audit/rules.d/00_audit.rules
     - source: salt://audit/files/audit.rules
     - template: jinja
+    - mode: 0640
+
+auditd-immutable:
+  file.managed:
+    - name: /etc/audit/rules.d/99_immutable.rules
+    - source: salt://audit/files/immutable.rules
     - mode: 0640
 
 audispd-conf:

--- a/audit/init.sls
+++ b/audit/init.sls
@@ -37,3 +37,20 @@ audispd-conf:
     - source: salt://audit/files/audispd.conf
     - template: jinja
     - mode: 0640
+
+auditd-service:
+  service.running:
+    - name: auditd
+    - require:
+        - pkg: auditd-pkg
+        - file: auditd-sysconfig
+        - file: auditd-conf
+        - file: auditd-rules
+        - file: auditd-immutable
+        - file: audispd-conf
+    - watch:
+        - file: auditd-sysconfig
+        - file: auditd-conf
+        - file: auditd-rules
+        - file: auditd-immutable
+        - file: audispd-conf

--- a/pillar.example
+++ b/pillar.example
@@ -45,6 +45,14 @@ audit:
     # flag:
     # rate_limit:
     # backlog_limit: 320
+    ## define custom rules here
+    # rules:
+    #   - -w /var/log/audit/ -k auditlog
+    #   - -w /etc/audit/ -p wa -k auditconfig
+    #   - -w /etc/libaudit.conf -p wa -k auditconfig
+    #   - -w /etc/audisp/ -p wa -k audispconfig
+    #   - -w /sbin/auditctl -p x -k audittools
+    #   - -w /sbin/auditd -p x -k audittools
 
   audispd:
     ## parameters for audit dispatcher daemon


### PR DESCRIPTION
These changes allow auditd rules to be managed by pillar.
- We change the path of the managed audit.rules file to /etc/audit/rules.d/ and change the name of the managed file to 00_audit.rules to ensure that it is read first.
- We create pillar logic such that a list of rules in audit:auditctl:rules will be read and added to 00_audit.rules.
- We add a new file called 99_immutable.rules (read last) to ensure that auditd rules are set as immutable automatically.
- We update the init.sls file so that the /etc/audit/audit.rules file is auto generated based on the contents of the /etc/audit/rules.d/ directory.
- We further update the init.sls file so that auditd is restarted any time that configuration files change.

The changes allow users to manage application specific auditd rules granularly and apply them only where they are needed.